### PR TITLE
test: add test to break variable hiding protocol

### DIFF
--- a/field/field.go
+++ b/field/field.go
@@ -40,7 +40,7 @@ func (field *Field) Exp(a, pow int64) int64 {
 	// by finding the multiplicative inverse of the base, and converting the exponent
 	// to its positive version.
 	// a^-b => (a^-1)^b
-	// a^-1 is the multiplicative inverse of a.
+	// a^-1 is the multiplicative inverse of a
 	if pow < 0 {
 		a = field.MultiplicativeInverse(a)
 		pow *= -1

--- a/field/field.go
+++ b/field/field.go
@@ -90,5 +90,5 @@ func (field *Field) MultiplicativeInverse(b int64) int64 {
 
 func (field *Field) RandomElement() int64 {
 	rand.Seed(time.Now().UnixNano())
-	return rand.Int63n(field.Order)
+	return rand.Int63n(field.Order-1) + 1
 }

--- a/main_test.go
+++ b/main_test.go
@@ -63,12 +63,14 @@ func TestProtocol(t *testing.T) {
 	}
 }
 
+// TODO: Find the relationship between the field and 100% probability here
+// 		changed to f* and is passing all the time.
 func TestBreakHE(t *testing.T) {
 	prime := int64(17707)
 	field := field.NewField(prime)
 	generator := 5
 
-	ITERATION_COUNT := 100000
+	ITERATION_COUNT := 1000000
 
 	for j := 0; j < ITERATION_COUNT; j++ {
 		verifier := NewVerifier(field, int64(generator), testCases[0].t_of_x)

--- a/main_test.go
+++ b/main_test.go
@@ -69,7 +69,7 @@ func TestBreakHE(t *testing.T) {
 	field := field.NewField(prime)
 	generator := 5
 
-	IterationCount := 1000000
+	IterationCount := 1000
 
 	for j := 0; j < IterationCount; j++ {
 		verifier := NewVerifier(field, int64(generator), testCases[0].tOfX)

--- a/main_test.go
+++ b/main_test.go
@@ -68,7 +68,7 @@ func TestBreakHE(t *testing.T) {
 	field := field.NewField(prime)
 	generator := 5
 
-	ITERATION_COUNT := 1000
+	ITERATION_COUNT := 100000
 
 	for j := 0; j < ITERATION_COUNT; j++ {
 		verifier := NewVerifier(field, int64(generator), testCases[0].t_of_x)
@@ -83,6 +83,12 @@ func TestBreakHE(t *testing.T) {
 
 		trickedVerifier := verifier.Verify(encryptedP, encryptedH)
 		if trickedVerifier != true {
+			// Print parameters
+			println("r", randomPoint)
+			println("g^r", encryptedH)
+			println("g^t", encryptedT)
+			println("g^t^r", encryptedP)
+			println("unencrypted t", PolyT.EvaluateAt(verifier.EvalT))
 			t.Errorf("Failed to convince the verifier of a false proof")
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -44,20 +44,20 @@ func TestProtocol(t *testing.T) {
 	field := field.NewField(prime)
 	generator := 5
 
-	ITERATION_COUNT := 1000
+	IterationCount := 1000
 
-	for j := 0; j < ITERATION_COUNT; j++ {
+	for j := 0; j < IterationCount; j++ {
 		for i, test := range testCases {
 			verifier := NewVerifier(field, int64(generator), test.t_of_x)
 
-			encrypted_powers_of_x := verifier.Setup()
+			encryptedPowersOfX := verifier.Setup()
 
 			prover := NewProver(field, test.p_of_x, test.h_of_x)
-			p, h := prover.Prove(encrypted_powers_of_x)
-			proofs_validity := verifier.Verify(p, h)
+			p, h := prover.Prove(encryptedPowersOfX)
+			proofsValidity := verifier.Verify(p, h)
 
-			if proofs_validity != test.is_valid {
-				t.Errorf("Test: %d, expected verifier to say %t, instead got %t", i, test.is_valid, proofs_validity)
+			if proofsValidity != test.is_valid {
+				t.Errorf("Test: %d, expected verifier to say %t, instead got %t", i, test.is_valid, proofsValidity)
 			}
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,12 @@ import (
 )
 
 type TestCase struct {
-	t_of_x, p_of_x, h_of_x []int64
-	is_valid               bool
+	tOfX, pOfX, hOfX []int64
+	isValid          bool
 }
 
 var testCases = []TestCase{
 	// TODO: write a simple compiler to accept polynomial in written form
-
 	// t(x) = x - 1 [-1, 1, 0, 0]
 	// p(x) = x^3 - 3x^2 + 2x [0, 2, -3, 1]
 	// h(x) = x^2 - 2x [0, -2, 1, 0]
@@ -37,7 +36,7 @@ var testCases = []TestCase{
 }
 
 // TODO: Completeness property breaks when I use larger primes e.g. 210403
-
+//			only soundness broke before
 func TestProtocol(t *testing.T) {
 	// parameters to the functions seems to have a big effect, how do we know what to pick
 	prime := int64(17707)
@@ -48,16 +47,16 @@ func TestProtocol(t *testing.T) {
 
 	for j := 0; j < IterationCount; j++ {
 		for i, test := range testCases {
-			verifier := NewVerifier(field, int64(generator), test.t_of_x)
+			verifier := NewVerifier(field, int64(generator), test.tOfX)
 
 			encryptedPowersOfX := verifier.Setup()
 
-			prover := NewProver(field, test.p_of_x, test.h_of_x)
+			prover := NewProver(field, test.pOfX, test.hOfX)
 			p, h := prover.Prove(encryptedPowersOfX)
 			proofsValidity := verifier.Verify(p, h)
 
-			if proofsValidity != test.is_valid {
-				t.Errorf("Test: %d, expected verifier to say %t, instead got %t", i, test.is_valid, proofsValidity)
+			if proofsValidity != test.isValid {
+				t.Errorf("Test: %d, expected verifier to say %t, instead got %t", i, test.isValid, proofsValidity)
 			}
 		}
 	}
@@ -70,22 +69,22 @@ func TestBreakHE(t *testing.T) {
 	field := field.NewField(prime)
 	generator := 5
 
-	ITERATION_COUNT := 1000000
+	IterationCount := 1000000
 
-	for j := 0; j < ITERATION_COUNT; j++ {
-		verifier := NewVerifier(field, int64(generator), testCases[0].t_of_x)
+	for j := 0; j < IterationCount; j++ {
+		verifier := NewVerifier(field, int64(generator), testCases[0].tOfX)
 		encryptedPowersOfX := verifier.Setup()
 
 		// Generate fake proof that fools the verifier with 100% probability
 		randomPoint := field.RandomElement()
 		encryptedH := EncryptValue(randomPoint, int64(generator), field)
-		PolyT := polynomial.NewPolynomial(field, testCases[0].t_of_x)
+		PolyT := polynomial.NewPolynomial(field, testCases[0].tOfX)
 		encryptedT := PolyT.EvaluateEncryptedPowers(encryptedPowersOfX)
 		encryptedP := field.Exp(encryptedT, randomPoint)
 
 		trickedVerifier := verifier.Verify(encryptedP, encryptedH)
 		if trickedVerifier != true {
-			// Print parameters
+			// Print parameters in case of failure
 			println("r", randomPoint)
 			println("g^r", encryptedH)
 			println("g^t", encryptedT)

--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
-run:
+test:
 	go clean -testcache && go test ./...

--- a/polynomial/polynomial.go
+++ b/polynomial/polynomial.go
@@ -47,8 +47,6 @@ func (poly *Polynomial) EvaluatePowers(powers []int64) int64 {
 
 // EvaluateEncryptedPowers does the same as EvaluatePowers but rather than doing addition (+)
 // it does multiplication (*) and rather than doing multiplication (*) it does exponentiation (^)
-// TODO: extract to homomorphic package, where addition and multiplication are implemented differently
-//		but interface if kept the same, that way we have a single evaluate powers function
 func (poly *Polynomial) EvaluateEncryptedPowers(powers []int64) int64 {
 	if len(powers) != len(poly.Coefficients) {
 		// TODO: get rid of panic, implement proper error handling

--- a/util.go
+++ b/util.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/iammadab/snark-protocol/field"
+import (
+	"github.com/iammadab/snark-protocol/field"
+	"math"
+)
 
 func GenerateEncryptedPowers(point int64, degree int, generator int64, field *field.Field) []int64 {
 	var encryptedPowers []int64
@@ -10,4 +13,9 @@ func GenerateEncryptedPowers(point int64, degree int, generator int64, field *fi
 		encryptedPowers = append(encryptedPowers, encryptedValue)
 	}
 	return encryptedPowers
+}
+
+// IntPow performs integer exponentiation
+func IntPow(a, b int64) int64 {
+	return int64(math.Pow(float64(a), float64(b)))
 }

--- a/util.go
+++ b/util.go
@@ -9,10 +9,14 @@ func GenerateEncryptedPowers(point int64, degree int, generator int64, field *fi
 	var encryptedPowers []int64
 	for i := 0; i <= degree; i++ {
 		power := IntPow(point, int64(i))
-		encryptedValue := field.Exp(generator, power)
+		encryptedValue := EncryptValue(power, generator, field)
 		encryptedPowers = append(encryptedPowers, encryptedValue)
 	}
 	return encryptedPowers
+}
+
+func EncryptValue(point int64, generator int64, field *field.Field) int64 {
+	return field.Exp(generator, point)
 }
 
 // IntPow performs integer exponentiation

--- a/util.go
+++ b/util.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/iammadab/snark-protocol/field"
+
+func GenerateEncryptedPowers(point int64, degree int, generator int64, field *field.Field) []int64 {
+	var encryptedPowers []int64
+	for i := 0; i <= degree; i++ {
+		power := IntPow(point, int64(i))
+		encryptedValue := field.Exp(generator, power)
+		encryptedPowers = append(encryptedPowers, encryptedValue)
+	}
+	return encryptedPowers
+}

--- a/verifier.go
+++ b/verifier.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/iammadab/snark-protocol/field"
 	"github.com/iammadab/snark-protocol/polynomial"
-	"math"
 )
 
 // TODO: need the concept of public information and private information
@@ -40,13 +39,4 @@ func (verifier *Verifier) Verify(encryptedP, encryptedH int64) bool {
 	ht := verifier.Field.Mod(verifier.Field.Exp(encryptedH, verifier.EvalT))
 
 	return p == ht
-}
-
-func (verifier *Verifier) EncryptValue(val int64) int64 {
-	return verifier.Field.Exp(verifier.Generator, val)
-}
-
-// IntPow performs integer exponentiation
-func IntPow(a, b int64) int64 {
-	return int64(math.Pow(float64(a), float64(b)))
 }

--- a/verifier.go
+++ b/verifier.go
@@ -30,14 +30,7 @@ func NewVerifier(field *field.Field, generator int64, coefficients []int64) *Ver
 // and also generate the encrypted powers of s for the prover
 func (verifier *Verifier) Setup() []int64 {
 	verifier.EvalT = verifier.PolyT.EvaluateAt(verifier.EvalPoint)
-
-	var encryptedPowers []int64
-	for i := 0; i <= verifier.PolyT.Degree(); i++ {
-		power := IntPow(verifier.EvalPoint, int64(i))
-		encryptedPowers = append(encryptedPowers, verifier.EncryptValue(power))
-	}
-
-	return encryptedPowers
+	return GenerateEncryptedPowers(verifier.EvalPoint, verifier.PolyT.Degree(), verifier.Generator, verifier.Field)
 }
 
 // Verify checks that p = ht in encrypted space


### PR DESCRIPTION
The verifier hides the evaluation point by encrypting it before sending it to the prover.
This pr adds a test that shows the current protocol is insufficient and can still be broken with 100% probability. 