### PR TITLE
feat: add zero knowledge logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Then test the function that breaks the protocol with:
 ```
 
 ### Polynomial Restriction
-
 To prevent the attack from the last stage, we need to be able to detect when the verifier uses variable powers different from what the verifier provides.
 This is based on the knowledge of exponent assumption.
 
@@ -30,6 +29,16 @@ This is based on the knowledge of exponent assumption.
 
 ```shell
     go test --run TestPolynomialRestriction
+```
+
+### Zero Knowledge
+The verifier can still retrieve information about the polynomial p(x) (not sure how useful that information is tho).  
+The goal is to make sure the verifier learns nothing about p(x), hence the prover has to shift it's output by some hidden blinding factor while still preserving validity checks.
+
+No specific test in this case, as I don't know how to make use of the information gotten from the previous stages.
+
+```shell
+    git checkout zero-knowledge
 ```
 
 (other stages) TBD

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is based on the knowledge of exponent assumption.
 The verifier can still retrieve information about the polynomial p(x) (not sure how useful that information is tho).  
 The goal is to make sure the verifier learns nothing about p(x), hence the prover has to shift it's output by some hidden blinding factor while still preserving validity checks.
 
-No specific test in this case, as I don't know how to make use of the information gotten from the previous stages.
+No specific test in this case, as I don't know how to make use of the "knowledge" gotten from the previous stages.
 
 ```shell
     git checkout zero-knowledge

--- a/prover.go
+++ b/prover.go
@@ -6,12 +6,14 @@ import (
 )
 
 type Prover struct {
+	field *field.Field
 	PolyP polynomial.Polynomial
 	PolyH polynomial.Polynomial
 }
 
 func NewProver(field *field.Field, polyp []int64, polyh []int64) *Prover {
 	return &Prover{
+		field: field,
 		PolyP: *polynomial.NewPolynomial(field, polyp),
 		PolyH: *polynomial.NewPolynomial(field, polyh),
 	}
@@ -21,5 +23,12 @@ func (prover *Prover) Prove(powers []int64, shiftedPowers []int64) (int64, int64
 	encryptedEvaluationOfP := prover.PolyP.EvaluateEncryptedPowers(powers)
 	shiftedEvaluationOfP := prover.PolyP.EvaluateEncryptedPowers(shiftedPowers)
 	encryptedEvaluationOfH := prover.PolyH.EvaluateEncryptedPowers(powers)
+
+	// add zero knowledge
+	blindingFactor := prover.field.RandomElement()
+	encryptedEvaluationOfP = prover.field.Exp(encryptedEvaluationOfP, blindingFactor)
+	shiftedEvaluationOfP = prover.field.Exp(shiftedEvaluationOfP, blindingFactor)
+	encryptedEvaluationOfH = prover.field.Exp(encryptedEvaluationOfH, blindingFactor)
+
 	return encryptedEvaluationOfP, shiftedEvaluationOfP, encryptedEvaluationOfH
 }


### PR DESCRIPTION
Prevent the verifier from learning anything about p(x). The prover uses a blinding factor to shift outputs while preserving the ability of the verifier to make validity checks. 